### PR TITLE
Added Swagger integration to Author/BookController and updated dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.3.5"
     id("io.spring.dependency-management") version "1.1.6"
-    id("io.freefair.lombok") version "8.0.1" // Lombok plugin for automatic configuration
+    id("io.freefair.lombok") version "8.0.1"
+    id("org.springframework.boot") version "3.3.6" // Lombok plugin for automatic configuration
 }
 
 group = "guru.springframework"
@@ -30,6 +30,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
 }
 
 dependencyManagement {

--- a/src/main/java/guru/springframework/spring6webapp/controllers/AuthorController.java
+++ b/src/main/java/guru/springframework/spring6webapp/controllers/AuthorController.java
@@ -1,11 +1,19 @@
 package guru.springframework.spring6webapp.controllers;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import guru.springframework.spring6webapp.services.AuthorService;
+import guru.springframework.spring6webapp.domain.Author;
 
-@Controller
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/authors")
+@Tag(name = "Author Controller", description = "API for managing authors")
 public class AuthorController {
 
     private final AuthorService authorService;
@@ -14,9 +22,9 @@ public class AuthorController {
         this.authorService = authorService;
     }
 
-    @RequestMapping("/authors")
-    public String getAuthors(Model model) {
-        model.addAttribute("authors", authorService.findAll());
-        return "authors";
+    @GetMapping
+    @Operation(summary = "Get all authors", description = "Returns a list of all authors")
+    public List<Author> getAuthors() {
+        return (List<Author>) authorService.findAll();
     }
 }

--- a/src/main/java/guru/springframework/spring6webapp/controllers/BookController.java
+++ b/src/main/java/guru/springframework/spring6webapp/controllers/BookController.java
@@ -1,11 +1,19 @@
 package guru.springframework.spring6webapp.controllers;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import guru.springframework.spring6webapp.services.BookService;
+import guru.springframework.spring6webapp.domain.Book;
 
-@Controller
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/books")
+@Tag(name = "Book Controller", description = "API for managing books")
 public class BookController {
 
     private final BookService bookService;
@@ -14,9 +22,9 @@ public class BookController {
         this.bookService = bookService;
     }
 
-    @RequestMapping("/books")
-    public String getBooks(Model model) {
-        model.addAttribute("books", bookService.findAll());
-        return "books";
+    @GetMapping
+    @Operation(summary = "Get all books", description = "Returns a list of all books")
+    public List<Book> getBooks() {
+        return (List<Book>) bookService.findAll();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,7 @@ spring.datasource.password=
 
 # OpenAI API Key (placeholder, replace with your actual key)
 spring.ai.openai.api-key=YOUR_OPENAI_API_KEY
+
+# Swagger / OpenAPI
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
Added 
build.gradle.kts
id("org.springframework.boot") version "3.3.6"   to plugins in build.gradle.kts
implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")   to dependencies in build.gradle.kts

Added
to application.propeties
springdoc.api-docs.path=/api-docs
springdoc.swagger-ui.path=/swagger-ui.html

Added to Controller
@RestController: Converts the controller to a RESTful controller.
@RequestMapping("/api/v1/authors"): Specifies the base URL for the controller.
@Tag(name, description): Provides metadata for the Swagger UI.
@Operation(summary, description): Adds details for the endpoint in the Swagger documentation.
@GetMapping: Defines the HTTP GET method for retrieving authors.



